### PR TITLE
added a daily check for text businesses to real businesses

### DIFF
--- a/lib/tasks/daily_functions.rake
+++ b/lib/tasks/daily_functions.rake
@@ -4,4 +4,38 @@ namespace :daily_functions do
     User.all.map(&:get_daily_suggestion)
   end
 
+  task check_for_text_businesses: :environment do
+    # Update any other_competitors which are now real businesses
+    Business.where.not(other_competitors: []).each do |bus|
+      bus.other_competitors.each do |comp|
+        if comp_bus = Business.find_by(name: comp)
+          bus.competitions.create(competitor: comp_bus)
+          bus.other_competitors -= [comp]
+          bus.save
+        end
+      end
+    end
+
+    # Update any other_partners which are now real businesses
+    Business.where.not(other_partners: []).each do |bus|
+      acquired = false
+      bus.other_partners.each do |partner|
+        if  partner[-6..-1] == " (acq)"
+          p_name = partner[0..-7]
+          acquired = true
+        elsif partner[-6..-1] == " (des)"
+          p_name = partner[0..-7]
+        else
+          p_name = partner
+        end
+
+        if p_bus = Business.find_by(name: p_name)
+          bus.partnerships.create(partner: p_bus, acquired: acquired)
+          bus.other_partners -= [partner]
+          bus.save
+        end
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
this function is executed daily via a rake file using the Heroku Scheduler and checks if any businesses which are simply text names in 'other_competitors' or 'other_partnerships' have been created that day and can be removed from the text list and added as real competitors/partners